### PR TITLE
exact one o clock without s at the end - ein Uhr

### DIFF
--- a/src/c/num2words-de.c
+++ b/src/c/num2words-de.c
@@ -73,7 +73,7 @@ void time_to_3words_DE(int hours, int minutes, int *LineBold,char *line1, char *
   hours=hours % 12;
   // Exceptions first
   if (minutes==0 ){
-    if(((hours==1)||(hours==13)){
+    if((hours==1)||(hours==13)){
       //exact one o clock without s at the end - ein Uhr
       strcpy(line1, "ein");
     }

--- a/src/c/num2words-de.c
+++ b/src/c/num2words-de.c
@@ -73,7 +73,13 @@ void time_to_3words_DE(int hours, int minutes, int *LineBold,char *line1, char *
   hours=hours % 12;
   // Exceptions first
   if (minutes==0 ){
-    strcpy(line1, HOUR_DE[hours]);
+    if(((hours==1)||(hours==13)){
+      //exact one o clock without s at the end - ein Uhr
+      strcpy(line1, "ein");
+    }
+    else {
+      strcpy(line1, HOUR_DE[hours]);
+    }
     strcpy(line2,MIN_DE1[minutes]);
     *LineBold=1;
   }


### PR DESCRIPTION
Hi, this is a special exception in the german language, if its exactly 01:00 or 13:00 you would say "ein Uhr", "eins" is only correct with minutes.